### PR TITLE
Increment Max Cape alpha shortcuts by 1

### DIFF
--- a/tags/beginner/details.json
+++ b/tags/beginner/details.json
@@ -30,7 +30,7 @@
     },
     {
         "id": 3,
-        "text": "MAX B: e Doric",
+        "text": "MAX C: e Doric",
         "color": "#FFC8C8C8",
         "itemIds": [
             13280,

--- a/tags/easy/details.json
+++ b/tags/easy/details.json
@@ -222,7 +222,7 @@
     },
     {
         "id": 2695,
-        "text": "MAX A: e fish crate",
+        "text": "MAX B: e fish crate",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -257,7 +257,7 @@
     },
     {
         "id": 2698,
-        "text": "MAX B: e Doric",
+        "text": "MAX C: e Doric",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -266,7 +266,7 @@
     },
     {
         "id": 2699,
-        "text": "MAX B: sw Gaius",
+        "text": "MAX C: sw Gaius",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -499,7 +499,7 @@
     },
     {
         "id": 3492,
-        "text": "MAX H: se drawer",
+        "text": "MAX I: se drawer",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -522,7 +522,7 @@
     },
     {
         "id": 3494,
-        "text": "MAX A: se stair",
+        "text": "MAX B: se stair",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -531,7 +531,7 @@
     },
     {
         "id": 3495,
-        "text": "MAX A: e up chest",
+        "text": "MAX B: e up chest",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -540,7 +540,7 @@
     },
     {
         "id": 3496,
-        "text": "MAX A: e Tobias",
+        "text": "MAX B: e Tobias",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -573,7 +573,7 @@
     },
     {
         "id": 3499,
-        "text": "MAX B: sw box",
+        "text": "MAX C: sw box",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -582,7 +582,7 @@
     },
     {
         "id": 3500,
-        "text": "MAX B: s drawer",
+        "text": "MAX C: s drawer",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -983,7 +983,7 @@
     },
     {
         "id": 10202,
-        "text": "MAX A: mine stash",
+        "text": "MAX B: mine stash",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1049,7 +1049,7 @@
     },
     {
         "id": 10210,
-        "text": "MAX B: ne stash",
+        "text": "MAX C: ne stash",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1474,7 +1474,7 @@
     },
     {
         "id": 12184,
-        "text": "MAX B: s Jatix",
+        "text": "MAX C: s Jatix",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1537,7 +1537,7 @@
     },
     {
         "id": 12189,
-        "text": "MAX A: mine wheel",
+        "text": "MAX B: mine wheel",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1563,7 +1563,7 @@
     },
     {
         "id": 12191,
-        "text": "MAX B: climb",
+        "text": "MAX C: climb",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1618,7 +1618,7 @@
     },
     {
         "id": 19818,
-        "text": "MAX D: s drawer",
+        "text": "MAX E: s drawer",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1661,7 +1661,7 @@
     },
     {
         "id": 19822,
-        "text": "MAX A: w Chemist",
+        "text": "MAX B: w Chemist",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1785,7 +1785,7 @@
     },
     {
         "id": 23149,
-        "text": "MAX B: crystal box",
+        "text": "MAX C: crystal box",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -1820,7 +1820,7 @@
     },
     {
         "id": 23153,
-        "text": "MAX A: sw crate",
+        "text": "MAX B: sw crate",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,
@@ -2091,7 +2091,7 @@
     },
     {
         "id": 29853,
-        "text": "MAX E: sw dig",
+        "text": "MAX F: sw dig",
         "color": "#FF4CCA27",
         "itemIds": [
             13280,

--- a/tags/elite/details.json
+++ b/tags/elite/details.json
@@ -154,7 +154,7 @@
     },
     {
         "id": 12082,
-        "text": "MAX B: hero stash",
+        "text": "MAX C: hero stash",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,
@@ -182,7 +182,7 @@
     },
     {
         "id": 12085,
-        "text": "MAX E: +gp 6 dtooth",
+        "text": "MAX F: +gp 6 dtooth",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,
@@ -958,7 +958,7 @@
     },
     {
         "id": 12156,
-        "text": "MAX B: stones",
+        "text": "MAX C: stones",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,
@@ -1155,7 +1155,7 @@
     },
     {
         "id": 19791,
-        "text": "MAX H: climb stash",
+        "text": "MAX I: climb stash",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,
@@ -1223,7 +1223,7 @@
     },
     {
         "id": 19798,
-        "text": "MAX I: waterfiend",
+        "text": "MAX J: waterfiend",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,
@@ -1368,7 +1368,7 @@
     },
     {
         "id": 19813,
-        "text": "MAX D: e dig",
+        "text": "MAX E: e dig",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,
@@ -1465,7 +1465,7 @@
     },
     {
         "id": 23770,
-        "text": "MAX I: ne dig",
+        "text": "MAX J: ne dig",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,
@@ -1545,7 +1545,7 @@
     },
     {
         "id": 25786,
-        "text": "MAX D: sw stash",
+        "text": "MAX E: sw stash",
         "color": "#FFB7FF00",
         "itemIds": [
             13280,

--- a/tags/hard/details.json
+++ b/tags/hard/details.json
@@ -311,7 +311,7 @@
     },
     {
         "id": 2778,
-        "text": "MAX A: e Gerrant",
+        "text": "MAX B: e Gerrant",
         "color": "#FFC15FFF",
         "itemIds": [
             13280,
@@ -667,7 +667,7 @@
     },
     {
         "id": 3538,
-        "text": "MAX E: 8 dig",
+        "text": "MAX F: 8 dig",
         "color": "#FFC15FFF",
         "itemIds": [
             13280,
@@ -727,7 +727,7 @@
     },
     {
         "id": 3546,
-        "text": "MAX H: Gu'T",
+        "text": "MAX I: Gu'T",
         "color": "#FFC15FFF",
         "itemIds": [
             13280,
@@ -810,7 +810,7 @@
     },
     {
         "id": 3560,
-        "text": "MAX E: 9 dig",
+        "text": "MAX F: 9 dig",
         "color": "#FFC15FFF",
         "itemIds": [
             13280,
@@ -842,7 +842,7 @@
     },
     {
         "id": 3564,
-        "text": "MAX E: 9 General",
+        "text": "MAX F: 9 General",
         "color": "#FFC15FFF",
         "itemIds": [
             13280,
@@ -1700,7 +1700,7 @@
     },
     {
         "id": 12578,
-        "text": "MAX G: Saniboch",
+        "text": "MAX H: Saniboch",
         "color": "#FFC15FFF",
         "itemIds": [
             13280,
@@ -2178,7 +2178,7 @@
     },
     {
         "id": 19898,
-        "text": "MAX I: sw Eluned",
+        "text": "MAX J: sw Eluned",
         "color": "#FFC15FFF",
         "itemIds": [
             13280,

--- a/tags/master/details.json
+++ b/tags/master/details.json
@@ -275,7 +275,7 @@
     },
     {
         "id": 525,
-        "text": "MAX D: cc isle dig",
+        "text": "MAX E: cc isle dig",
         "color": "#FFFF5A00",
         "itemIds": [
             13280,
@@ -1821,7 +1821,7 @@
     },
     {
         "id": 646,
-        "text": "MAX B: se dig",
+        "text": "MAX C: se dig",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,
@@ -1889,7 +1889,7 @@
     },
     {
         "id": 652,
-        "text": "MAX A: mine dig",
+        "text": "MAX B: mine dig",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,
@@ -2004,7 +2004,7 @@
     },
     {
         "id": 660,
-        "text": "MAX C: smoke dig",
+        "text": "MAX D: smoke dig",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,
@@ -2688,7 +2688,7 @@
     },
     {
         "id": 706,
-        "text": "MAX G: sw dig",
+        "text": "MAX H: sw dig",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,
@@ -2965,7 +2965,7 @@
     },
     {
         "id": 726,
-        "text": "MAX E: +gp 6 dtooth n",
+        "text": "MAX F: +gp 6 dtooth n",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,
@@ -2983,7 +2983,7 @@
     },
     {
         "id": 727,
-        "text": "MAX E: +gp 6 dtooth s",
+        "text": "MAX F: +gp 6 dtooth s",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,
@@ -3079,7 +3079,7 @@
     },
     {
         "id": 733,
-        "text": "MAX E: theatre dig",
+        "text": "MAX F: theatre dig",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,
@@ -3182,7 +3182,7 @@
     },
     {
         "id": 741,
-        "text": "MAX E: +gp 9 dig",
+        "text": "MAX F: +gp 9 dig",
         "color": "#FFFF5A00",
         "itemIds": [
             19939,

--- a/tags/medium/details.json
+++ b/tags/medium/details.json
@@ -29,7 +29,7 @@
     },
     {
         "id": 2805,
-        "text": "MAX G: isle dig",
+        "text": "MAX H: isle dig",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,
@@ -464,7 +464,7 @@
     },
     {
         "id": 3590,
-        "text": "MAX G: sw dig",
+        "text": "MAX H: sw dig",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,
@@ -555,7 +555,7 @@
     },
     {
         "id": 3602,
-        "text": "MAX A: chem dig",
+        "text": "MAX B: chem dig",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,
@@ -897,7 +897,7 @@
     },
     {
         "id": 7303,
-        "text": "MAX C: camp",
+        "text": "MAX D: camp",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,
@@ -1371,7 +1371,7 @@
     },
     {
         "id": 12039,
-        "text": "MAX F: potato",
+        "text": "MAX G: potato",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,
@@ -1511,7 +1511,7 @@
     },
     {
         "id": 12061,
-        "text": "MAX A: e Tobias",
+        "text": "MAX B: e Tobias",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,
@@ -1520,7 +1520,7 @@
     },
     {
         "id": 12063,
-        "text": "MAX A: w Taria",
+        "text": "MAX B: w Taria",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,
@@ -1786,7 +1786,7 @@
     },
     {
         "id": 19768,
-        "text": "MAX C: Kebab",
+        "text": "MAX D: Kebab",
         "color": "#FF4BB7FF",
         "itemIds": [
             13280,


### PR DESCRIPTION
Sailing added a new Max Cape teleport option, `9: The Pandemonium` and as a result we need to increment all of the POH teleports by 1